### PR TITLE
Fix broken link to SoundPipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ graphics library. Persistent data storage is provided via
 Realtime audio is achieved using 
 [RtAudio](https://www.github.com/thestk/rtaudio), and digitial signal processing is 
 built on top of the musical audio signal processing library 
-[Soundpipe](http://www.pbat.ch/proj/soundpipe).
+[Soundpipe](http://www.pbat.ch/proj/soundpipe.html).
 
 ## Usage
 


### PR DESCRIPTION
Hi!

I just came across this repo on Twitter, very interesting! I noticed that the link to SoundPipe was broken, so here's a fix.

There seems to be a mirror of the SoundPipe page at [http://paulbatchelor.github.io/proj/soundpipe.html](http://paulbatchelor.github.io/proj/soundpipe.html), would that be a better url?